### PR TITLE
Clarify product category comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
     </div>
 
     <script>
-        // Productos reales: Árabes y Diseñador
+        // La constante productos incluye categorías "Árabes" y "Diseñador"; las decants se definen aparte
         const productos = [
             { nombre: "Al Haramain Amber Oud Gold Unisex 120ML", imagenes: ["images/Amber oud gold.jpeg", "images/Amber oud gold2.jpeg"], categoria: "Árabes", precio: 85000, descripcion: "", stock: true },
             { nombre: "Armaf Club de Nuit intense man EDT 100ML", imagenes: ["images/Club de nuit intense.jpeg"], categoria: "Árabes", precio: 48000, descripcion: "", stock: true },


### PR DESCRIPTION
## Summary
- clarify that `productos` includes "Árabes" and "Diseñador" categories while decants are defined separately

## Testing
- `./test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6891fa82650c8330bf1954bb0c9bab86