### PR TITLE
Add Excel-backed stock and order APIs

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -67,10 +67,44 @@ function updateCart() {
   cartTotal.textContent = `$${total.toLocaleString('es-AR')}`;
 }
 
+async function getStockLevels() {
+  const res = await fetch('/api/stock');
+  if (!res.ok) throw new Error('Failed to fetch stock');
+  return res.json();
+}
+
+async function submitOrder(order) {
+  const res = await fetch('/api/orders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(order)
+  });
+  if (!res.ok) throw new Error('Failed to submit order');
+  return res.json();
+}
+
+async function checkout() {
+  try {
+    await submitOrder({ items: cart });
+    await fetch('/api/stock', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ items: cart })
+    });
+    cart.length = 0;
+    updateCart();
+  } catch (err) {
+    console.error('Checkout failed', err);
+  }
+}
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { cart, addToCart, updateCart };
+  module.exports = { cart, addToCart, updateCart, getStockLevels, submitOrder, checkout };
 } else {
   window.cart = cart;
   window.addToCart = addToCart;
   window.updateCart = updateCart;
+  window.getStockLevels = getStockLevels;
+  window.submitOrder = submitOrder;
+  window.checkout = checkout;
 }

--- a/index.html
+++ b/index.html
@@ -946,7 +946,16 @@
         });
 
         // Inicialización
-        document.addEventListener('DOMContentLoaded', () => {
+        document.addEventListener('DOMContentLoaded', async () => {
+            try {
+                const stockData = await getStockLevels();
+                stockData.forEach(item => {
+                    const prod = productos.find(p => p.nombre === item.Producto);
+                    if (prod) prod.stock = item.Cantidad > 0;
+                });
+            } catch (err) {
+                console.error('Error fetching stock', err);
+            }
             renderProductos();
             updateCompareButton();
         });

--- a/package.json
+++ b/package.json
@@ -7,10 +7,15 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "xlsx": "^0.18.5"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,100 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const XLSX = require('xlsx');
+
+const app = express();
+app.use(express.json());
+
+const FILE = path.join(__dirname, 'stock.xlsx');
+const STOCK_SHEET = 'Stock';
+const ORDERS_SHEET = 'Pedidos';
+
+let writePromise = Promise.resolve();
+
+function runExclusive(task) {
+  writePromise = writePromise.then(() => task());
+  return writePromise;
+}
+
+function readWorkbook() {
+  if (fs.existsSync(FILE)) {
+    return XLSX.readFile(FILE);
+  }
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.json_to_sheet([]);
+  XLSX.utils.book_append_sheet(wb, ws, STOCK_SHEET);
+  XLSX.writeFile(wb, FILE);
+  return wb;
+}
+
+app.get('/api/stock', (req, res) => {
+  try {
+    const wb = readWorkbook();
+    const ws = wb.Sheets[STOCK_SHEET];
+    const data = XLSX.utils.sheet_to_json(ws);
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load stock' });
+  }
+});
+
+app.post('/api/stock', (req, res) => {
+  const items = req.body.items;
+  if (!Array.isArray(items)) {
+    return res.status(400).json({ error: 'items array required' });
+  }
+
+  runExclusive(async () => {
+    const wb = readWorkbook();
+    const ws = wb.Sheets[STOCK_SHEET];
+    const data = XLSX.utils.sheet_to_json(ws);
+
+    items.forEach(({ name, quantity }) => {
+      const row = data.find(r => r.Producto === name);
+      if (row) {
+        row.Cantidad = Math.max(0, (row.Cantidad || 0) - quantity);
+      }
+    });
+
+    wb.Sheets[STOCK_SHEET] = XLSX.utils.json_to_sheet(data);
+    XLSX.writeFile(wb, FILE);
+  }).then(() => {
+    res.json({ success: true });
+  }).catch(err => {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to update stock' });
+  });
+});
+
+app.post('/api/orders', (req, res) => {
+  const order = req.body;
+  if (!order) {
+    return res.status(400).json({ error: 'order required' });
+  }
+
+  runExclusive(async () => {
+    const wb = readWorkbook();
+    let ws = wb.Sheets[ORDERS_SHEET];
+    const data = ws ? XLSX.utils.sheet_to_json(ws) : [];
+    data.push({ ...order, timestamp: new Date().toISOString() });
+    ws = XLSX.utils.json_to_sheet(data);
+    wb.Sheets[ORDERS_SHEET] = ws;
+    if (!wb.SheetNames.includes(ORDERS_SHEET)) {
+      wb.SheetNames.push(ORDERS_SHEET);
+    }
+    XLSX.writeFile(wb, FILE);
+  }).then(() => {
+    res.json({ success: true });
+  }).catch(err => {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save order' });
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- implement Express server with Excel-backed `/api/stock` and `/api/orders`
- add front-end hooks to fetch stock levels and submit orders
- expose checkout logic and add server dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68921697eb588330bfc6c0e224535384