### PR TITLE
Add order form and backend Excel storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+stock.xlsx

--- a/index.html
+++ b/index.html
@@ -268,6 +268,17 @@
                 <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16" id="decantsGrid"></div>
             </div>
         </div>
+
+        <section class="my-12">
+            <h2 class="text-2xl font-bold mb-4 text-center">Realizar Pedido</h2>
+            <form id="order-form" class="max-w-md mx-auto grid gap-4">
+                <input type="tel" id="order-phone" class="border rounded p-2" placeholder="Número de teléfono" required>
+                <input type="text" id="order-perfume" class="border rounded p-2" placeholder="Perfume" required>
+                <input type="number" id="order-quantity" class="border rounded p-2" placeholder="Cantidad" min="1" required>
+                <button type="submit" class="bg-gray-800 text-white px-4 py-2 rounded hover:bg-gray-700">Enviar Pedido</button>
+            </form>
+            <p id="order-message" class="text-center mt-2 text-sm"></p>
+        </section>
     </main>
 
     <footer class="bg-gray-800 text-white py-12 mt-12">
@@ -958,6 +969,24 @@
             }
             renderProductos();
             updateCompareButton();
+
+            const orderForm = document.getElementById('order-form');
+            if (orderForm) {
+                orderForm.addEventListener('submit', async (e) => {
+                    e.preventDefault();
+                    const phone = document.getElementById('order-phone').value;
+                    const perfume = document.getElementById('order-perfume').value;
+                    const quantity = parseInt(document.getElementById('order-quantity').value, 10);
+                    try {
+                        await submitOrder({ phone, perfume, quantity });
+                        document.getElementById('order-message').textContent = 'Pedido enviado correctamente';
+                        orderForm.reset();
+                    } catch (err) {
+                        console.error('Error submitting order', err);
+                        document.getElementById('order-message').textContent = 'Error al enviar el pedido';
+                    }
+                });
+            }
         });
     </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -68,16 +68,16 @@ app.post('/api/stock', (req, res) => {
 });
 
 app.post('/api/orders', (req, res) => {
-  const order = req.body;
-  if (!order) {
-    return res.status(400).json({ error: 'order required' });
+  const { phone, perfume, quantity } = req.body || {};
+  if (!phone || !perfume || typeof quantity !== 'number') {
+    return res.status(400).json({ error: 'phone, perfume and quantity required' });
   }
 
   runExclusive(async () => {
     const wb = readWorkbook();
     let ws = wb.Sheets[ORDERS_SHEET];
     const data = ws ? XLSX.utils.sheet_to_json(ws) : [];
-    data.push({ ...order, timestamp: new Date().toISOString() });
+    data.push({ Telefono: phone, Perfume: perfume, Cantidad: quantity, timestamp: new Date().toISOString() });
     ws = XLSX.utils.json_to_sheet(data);
     wb.Sheets[ORDERS_SHEET] = ws;
     if (!wb.SheetNames.includes(ORDERS_SHEET)) {
@@ -93,8 +93,10 @@ app.post('/api/orders', (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
 
 module.exports = app;

--- a/tests/orders.test.js
+++ b/tests/orders.test.js
@@ -1,0 +1,37 @@
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const XLSX = require('xlsx');
+const app = require('../server');
+
+const FILE = path.join(__dirname, '..', 'stock.xlsx');
+
+beforeEach(() => {
+  if (fs.existsSync(FILE)) fs.unlinkSync(FILE);
+});
+
+test('saves order with phone, perfume and quantity', async () => {
+  const server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  const port = server.address().port;
+
+  const res = await fetch(`http://localhost:${port}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ phone: '12345', perfume: 'Test', quantity: 2 })
+  });
+
+  assert.strictEqual(res.status, 200);
+  await res.json();
+
+  const wb = XLSX.readFile(FILE);
+  const ws = wb.Sheets['Pedidos'];
+  const data = XLSX.utils.sheet_to_json(ws);
+  assert.strictEqual(data.length, 1);
+  assert.strictEqual(data[0].Telefono, '12345');
+  assert.strictEqual(data[0].Perfume, 'Test');
+  assert.strictEqual(data[0].Cantidad, 2);
+
+  server.close();
+});


### PR DESCRIPTION
## Summary
- Add `Pedidos` form where users enter phone, perfume and quantity
- Save orders to Excel backend with validation and conditional server start
- Add regression test for order saving and ignore generated files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68921c3187288330ad6790abe85bf184