### PR TITLE
Enviar pedido a WhatsApp y banner animado

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,17 @@
             from { transform: translateY(100%); }
             to { transform: translateY(0); }
         }
+
+        @keyframes marquee {
+            0% { transform: translateX(100%); }
+            100% { transform: translateX(-100%); }
+        }
+
+        .marquee {
+            display: inline-block;
+            white-space: nowrap;
+            animation: marquee 10s linear infinite;
+        }
     </style>
 </head>
 <body>
@@ -196,8 +207,11 @@
 
     <!-- Navegación superior -->
     <nav class="bg-white shadow">
-        <div class="container mx-auto px-4 py-4 flex justify-between">
+        <div class="container mx-auto px-4 py-4 flex items-center">
             <a href="index.html" class="font-bold text-gray-800">Inicio</a>
+            <div class="flex-1 mx-4 overflow-hidden">
+                <p class="marquee bg-yellow-200 text-gray-800 px-2 rounded">No te olvides de seguirnos en Instagram</p>
+            </div>
             <a href="pedido.html" class="text-gray-600 hover:text-gray-800">Realizar Pedido</a>
         </div>
     </nav>

--- a/pedido.html
+++ b/pedido.html
@@ -5,11 +5,26 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Realizar Pedido - TuPerfumería</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        @keyframes marquee {
+            0% { transform: translateX(100%); }
+            100% { transform: translateX(-100%); }
+        }
+
+        .marquee {
+            display: inline-block;
+            white-space: nowrap;
+            animation: marquee 10s linear infinite;
+        }
+    </style>
 </head>
 <body class="bg-gray-100">
     <nav class="bg-white shadow">
-        <div class="container mx-auto px-4 py-4 flex justify-between">
+        <div class="container mx-auto px-4 py-4 flex items-center">
             <a href="index.html" class="font-bold text-gray-800">Inicio</a>
+            <div class="flex-1 mx-4 overflow-hidden">
+                <p class="marquee bg-yellow-200 text-gray-800 px-2 rounded">No te olvides de seguirnos en Instagram</p>
+            </div>
             <a href="pedido.html" class="text-gray-600 hover:text-gray-800">Realizar Pedido</a>
         </div>
     </nav>
@@ -17,7 +32,7 @@
     <main class="container mx-auto px-4 my-12">
         <h2 class="text-2xl font-bold mb-4 text-center">Realizar Pedido</h2>
         <form id="order-form" class="max-w-md mx-auto grid gap-4">
-            <input type="tel" id="order-phone" class="border rounded p-2" placeholder="Número de teléfono" required>
+            <input type="text" id="order-name" class="border rounded p-2" placeholder="Nombre" required>
             <input type="text" id="order-perfume" class="border rounded p-2" placeholder="Perfume" required>
             <input type="number" id="order-quantity" class="border rounded p-2" placeholder="Cantidad" min="1" required>
             <button type="submit" class="bg-gray-800 text-white px-4 py-2 rounded hover:bg-gray-700">Enviar Pedido</button>
@@ -25,22 +40,15 @@
         <p id="order-message" class="text-center mt-2 text-sm"></p>
     </main>
 
-    <script src="cart.js"></script>
     <script>
-    const orderForm = document.getElementById('order-form');
-    orderForm.addEventListener('submit', async (e) => {
+    document.getElementById('order-form').addEventListener('submit', (e) => {
         e.preventDefault();
-        const phone = document.getElementById('order-phone').value;
+        const name = document.getElementById('order-name').value;
         const perfume = document.getElementById('order-perfume').value;
-        const quantity = parseInt(document.getElementById('order-quantity').value, 10);
-        try {
-            await submitOrder({ phone, perfume, quantity });
-            document.getElementById('order-message').textContent = 'Pedido enviado correctamente';
-            orderForm.reset();
-        } catch (err) {
-            console.error('Error submitting order', err);
-            document.getElementById('order-message').textContent = 'Error al enviar el pedido';
-        }
+        const quantity = document.getElementById('order-quantity').value;
+        const message = encodeURIComponent(`Nombre: ${name}\nPerfume: ${perfume}\nCantidad: ${quantity}`);
+        window.open(`https://wa.me/541138722792?text=${message}`, '_blank');
+        document.getElementById('order-form').reset();
     });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- Reemplazar formulario de pedidos para abrir WhatsApp con nombre, perfume y cantidad.
- Agregar banner animado en la navegación invitando a seguir en Instagram.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68922303ae248330a05b1225ce80fe13