### PR TITLE
Enviar pedidos vía WhatsApp y agregar barra animada

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,19 @@
             from { transform: translateY(100%); }
             to { transform: translateY(0); }
         }
+
+        .marquee {
+            overflow: hidden;
+            white-space: nowrap;
+        }
+        .marquee span {
+            display: inline-block;
+            animation: marquee 10s linear infinite;
+        }
+        @keyframes marquee {
+            0% { transform: translateX(100%); }
+            100% { transform: translateX(-100%); }
+        }
     </style>
 </head>
 <body>
@@ -196,8 +209,11 @@
 
     <!-- Navegación superior -->
     <nav class="bg-white shadow">
-        <div class="container mx-auto px-4 py-4 flex justify-between">
+        <div class="container mx-auto px-4 py-4 flex items-center">
             <a href="index.html" class="font-bold text-gray-800">Inicio</a>
+            <div class="marquee flex-1 mx-4">
+                <span class="text-gray-600">No te olvides de seguirnos en Instagram</span>
+            </div>
             <a href="pedido.html" class="text-gray-600 hover:text-gray-800">Realizar Pedido</a>
         </div>
     </nav>
@@ -970,19 +986,16 @@
 
             const orderForm = document.getElementById('order-form');
             if (orderForm) {
-                orderForm.addEventListener('submit', async (e) => {
+                orderForm.addEventListener('submit', (e) => {
                     e.preventDefault();
-                    const phone = document.getElementById('order-phone').value;
+                    const name = document.getElementById('order-name').value;
                     const perfume = document.getElementById('order-perfume').value;
-                    const quantity = parseInt(document.getElementById('order-quantity').value, 10);
-                    try {
-                        await submitOrder({ phone, perfume, quantity });
-                        document.getElementById('order-message').textContent = 'Pedido enviado correctamente';
-                        orderForm.reset();
-                    } catch (err) {
-                        console.error('Error submitting order', err);
-                        document.getElementById('order-message').textContent = 'Error al enviar el pedido';
-                    }
+                    const quantity = document.getElementById('order-quantity').value;
+                    const whatsappNumber = '+5491138722792';
+                    const message = `Hola, soy ${name}. Quiero pedir ${quantity} x ${perfume}.`;
+                    window.open(`https://wa.me/${whatsappNumber}?text=${encodeURIComponent(message)}`, '_blank');
+                    document.getElementById('order-message').textContent = 'Redirigiendo a WhatsApp...';
+                    orderForm.reset();
                 });
             }
         });

--- a/pedido.html
+++ b/pedido.html
@@ -5,11 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Realizar Pedido - TuPerfumería</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        .marquee {
+            overflow: hidden;
+            white-space: nowrap;
+        }
+        .marquee span {
+            display: inline-block;
+            animation: marquee 10s linear infinite;
+        }
+        @keyframes marquee {
+            0% { transform: translateX(100%); }
+            100% { transform: translateX(-100%); }
+        }
+    </style>
 </head>
 <body class="bg-gray-100">
     <nav class="bg-white shadow">
-        <div class="container mx-auto px-4 py-4 flex justify-between">
+        <div class="container mx-auto px-4 py-4 flex items-center">
             <a href="index.html" class="font-bold text-gray-800">Inicio</a>
+            <div class="marquee flex-1 mx-4">
+                <span class="text-gray-600">No te olvides de seguirnos en Instagram</span>
+            </div>
             <a href="pedido.html" class="text-gray-600 hover:text-gray-800">Realizar Pedido</a>
         </div>
     </nav>
@@ -17,7 +34,7 @@
     <main class="container mx-auto px-4 my-12">
         <h2 class="text-2xl font-bold mb-4 text-center">Realizar Pedido</h2>
         <form id="order-form" class="max-w-md mx-auto grid gap-4">
-            <input type="tel" id="order-phone" class="border rounded p-2" placeholder="Número de teléfono" required>
+            <input type="text" id="order-name" class="border rounded p-2" placeholder="Nombre" required>
             <input type="text" id="order-perfume" class="border rounded p-2" placeholder="Perfume" required>
             <input type="number" id="order-quantity" class="border rounded p-2" placeholder="Cantidad" min="1" required>
             <button type="submit" class="bg-gray-800 text-white px-4 py-2 rounded hover:bg-gray-700">Enviar Pedido</button>
@@ -25,22 +42,18 @@
         <p id="order-message" class="text-center mt-2 text-sm"></p>
     </main>
 
-    <script src="cart.js"></script>
     <script>
     const orderForm = document.getElementById('order-form');
-    orderForm.addEventListener('submit', async (e) => {
+    orderForm.addEventListener('submit', (e) => {
         e.preventDefault();
-        const phone = document.getElementById('order-phone').value;
+        const name = document.getElementById('order-name').value;
         const perfume = document.getElementById('order-perfume').value;
-        const quantity = parseInt(document.getElementById('order-quantity').value, 10);
-        try {
-            await submitOrder({ phone, perfume, quantity });
-            document.getElementById('order-message').textContent = 'Pedido enviado correctamente';
-            orderForm.reset();
-        } catch (err) {
-            console.error('Error submitting order', err);
-            document.getElementById('order-message').textContent = 'Error al enviar el pedido';
-        }
+        const quantity = document.getElementById('order-quantity').value;
+        const whatsappNumber = '+5491138722792';
+        const message = `Hola, soy ${name}. Quiero pedir ${quantity} x ${perfume}.`;
+        window.open(`https://wa.me/${whatsappNumber}?text=${encodeURIComponent(message)}`, '_blank');
+        document.getElementById('order-message').textContent = 'Redirigiendo a WhatsApp...';
+        orderForm.reset();
     });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- Envía los pedidos directamente a WhatsApp con nombre, perfume y cantidad.
- Añade una barra animada entre "Inicio" y "Realizar Pedido" recordando seguir la cuenta de Instagram.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892275eb1e08330971b7dbcc4fe0126